### PR TITLE
Fix jump size on Ancient Archives

### DIFF
--- a/ancient_archives/map.conf
+++ b/ancient_archives/map.conf
@@ -2,7 +2,7 @@ game_modes = return {"classes","nade_fight","classic"}
 barrier_area = return {pos1={x=0,y=0,z=0},pos2={x=144,y=43,z=232}}
 teams = local _={};_[1]="enabled";_[2]="flag_pos";return {blue={pos2={x=1,y=42,z=116},[_[1]]=true,pos1={x=143,y=-0.5,z=231},[_[2]]={x=72,y=20.5,z=215}},red={pos2={x=143,y=-0.5,z=1},[_[1]]=true,pos1={x=1,y=42,z=116},[_[2]]={x=72,y=20.5,z=17}}}
 chests = return {{amount=80,pos2={x=132,y=20.5,z=116},pos1={x=12,y=19.5,z=12}},{amount=80,pos2={x=132,y=20.5,z=220},pos1={x=11,y=19.5,z=117}}}
-phys_jump = 1.3
+phys_jump = 1
 phys_speed = 1.3
 size = return {x=144,y=43,z=232}
 map_version = 3


### PR DESCRIPTION
Jump size set to default (previously 1.3)

Ask by one of the map makers of this map: @1256253283656269866